### PR TITLE
删除控制台的chunks

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -5,5 +5,8 @@
       "presets": ["es2015", "stage-3", "react"]
     }
   },
-  "plugins": ["react-hot-loader/babel"]
+  "plugins": [
+    "react-hot-loader/babel",
+    "transform-runtime"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   "devDependencies": {
     "babel-core": "6.24.1",
     "babel-loader": "^6.2.10",
-    "babel-polyfill": "6.23.0",
+    "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-es2015": "^6.18.0",
     "babel-preset-react": "^6.16.0",
     "babel-preset-stage-3": "^6.17.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -99,6 +99,9 @@ const config = {
     host: 'localhost',
     port: Number(process.env.PORT) || 8080,
     historyApiFallback: true,
+    stats: {
+      chunks: false
+    }
   },
 };
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -30,7 +30,7 @@ HashBundlePlugin.prototype.apply = (compiler) => {
 };
 
 const config = {
-  entry: ['babel-polyfill', path.resolve(__dirname, 'src')],
+  entry: [path.resolve(__dirname, 'src')],
   output: {
     filename: `${isProd ? '[hash].' : ''}[name].js`,
     path: path.resolve(__dirname, 'build'),
@@ -113,7 +113,6 @@ if (!isProd) {
     'react-hot-loader/patch',
     `webpack-dev-server/client?http://${config.devServer.host}:${config.devServer.port}`,
     'webpack/hot/only-dev-server', // "only" prevents reload on syntax errors
-    'babel-polyfill',
     path.resolve(__dirname, 'src'),
   ];
 


### PR DESCRIPTION
控制台的chunks是一个不常用的功能，我们通常只需要打印编译成功后的文件信息，而忽略每一个js的编译情况。